### PR TITLE
add quotes to build event to fix character escape issues

### DIFF
--- a/InjectDemo.Console.ClassicNet/InjectDemo.Console.ClassicNet.csproj
+++ b/InjectDemo.Console.ClassicNet/InjectDemo.Console.ClassicNet.csproj
@@ -48,6 +48,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /y  $(TargetPath) ..\..\..\DNCIArticleConsoleApplication\bin\Debug\</PostBuildEvent>
+    <PostBuildEvent>xcopy /y  "$(TargetPath)" "..\..\..\DNCIArticleConsoleApplication\bin\Debug\"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
If your targetPath had spaces or weird characters it would cause a problem

This fixes the only error that occurs out of the box, once fixed no more errors :)